### PR TITLE
Add User-Agent and connection reuse

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func downloadJSON(url string) ([]byte, *http.Response, error) {
 		return []byte{}, nil, err
 	}
 
+	req.Header.Set("User-Agent", "ctail (+https://github.com/hdm/ctail)")
 	req.Header.Set("Accept", "application/json")
 
 	tr := &http.Transport{

--- a/main.go
+++ b/main.go
@@ -118,6 +118,10 @@ func scrubX509Value(s string) string {
 	return strings.ReplaceAll(s, "\x00", "")
 }
 
+var client = &http.Client{Transport: &http.Transport{
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+}}
+
 func downloadJSON(url string) ([]byte, *http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -126,12 +130,6 @@ func downloadJSON(url string) ([]byte, *http.Response, error) {
 
 	req.Header.Set("User-Agent", "ctail (+https://github.com/hdm/ctail)")
 	req.Header.Set("Accept", "application/json")
-
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client := &http.Client{Transport: tr}
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
The User-Agent helps log operators figure out what clients might need improvement, and connection reuse avoids a TLS handshake for every HTTP request.